### PR TITLE
Implement missing checks to enable beman-tidy with default mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,5 @@ repos:
     rev: v0.3.1
     hooks:
     - id: beman-tidy
-      args: [".", "--verbose", "--require-all"]
 
 exclude: 'cookiecutter/|infra/'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,4 +39,10 @@ repos:
     hooks:
       - id: codespell
 
+  - repo: https://github.com/bemanproject/beman-tidy
+    rev: v0.3.1
+    hooks:
+    - id: beman-tidy
+      args: [".", "--verbose", "--require-all"]
+
 exclude: 'cookiecutter/|infra/'

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 `beman.timed_lock_alg` implements timed lock algorithms for multiple lockables and `std::multi_lock`.
 
-**Implements**: `std::try_lock_until` and `std::try_lock_for` proposed in [Timed lock algorithms for multiple lockables (P3832)](https://wg21.link/p3832r1) and `std::multi_lock` proposed in [`std::multi_lock` (P3833)](https://wg21.link/p3833r2).
+**Implements**: `std::try_lock_until` and `std::try_lock_for` proposed in [Timed lock algorithms for multiple lockables (P3832)](https://wg21.link/P3832R1) and `std::multi_lock` proposed in [`std::multi_lock` (P3833)](https://wg21.link/P3833R2).
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 `beman.timed_lock_alg` implements timed lock algorithms for multiple lockables and `std::multi_lock`.
 
-**Implements**: `std::try_lock_until` and `std::try_lock_for` proposed in [Timed lock algorithms for multiple lockables (P3832)](https://isocpp.org/files/papers/P3832R1.html) and `std::multi_lock` proposed in [`std::multi_lock` (P3833)](https://isocpp.org/files/papers/P3833R2.html)
+**Implements**: `std::try_lock_until` and `std::try_lock_for` proposed in [Timed lock algorithms for multiple lockables (P3832)](https://wg21.link/p3832r1) and `std::multi_lock` proposed in [`std::multi_lock` (P3833)](https://wg21.link/p3833r2).
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use)
 


### PR DESCRIPTION
Issue: https://github.com/bemanproject/beman-tidy/issues/263

Updated README because **Implements** section doesn't align with beman rules.

Output for pre-commit ( all pass) :

```bash
teodorandrei@Teodors-MacBook-Pro timed_lock_alg % pre-commit run --verbose --all-files
trim trailing whitespace.................................................Passed
- hook id: trailing-whitespace
- duration: 0.05s
fix end of files.........................................................Passed
- hook id: end-of-file-fixer
- duration: 0.05s
check yaml...............................................................Passed
- hook id: check-yaml
- duration: 0.06s
check for added large files..............................................Passed
- hook id: check-added-large-files
- duration: 0.07s
clang-format.............................................................Passed
- hook id: clang-format
- duration: 0.06s
CMake linting............................................................Passed
- hook id: gersemi
- duration: 0.11s

Warning: unknown command 'beman_install_library' used at:
/Users/teodorandrei/Desktop/beman project/timed_lock_alg/CMakeLists.txt:45:1

codespell................................................................Passed
- hook id: codespell
- duration: 0.13s
beman-tidy...............................................................Passed
- hook id: beman-tidy
- duration: 0.2s

beman-tidy pipeline started ...

Running check [Requirement][license.approved] ... 
[info][license.approved]: Valid Apache License - Version 2.0 with LLVM Exceptions found in LICENSE file.
	check [Requirement][license.approved] ... passed

Running check [Requirement][license.apache_llvm] ... 
	check [Requirement][license.apache_llvm] ... passed

Running check [Requirement][license.criteria] ... 
[info][license.criteria]: beman-tidy cannot actually check license.criteria. Please ignore this message if license.approved has passed. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#licensecriteria for more information.
[skipped][license.criteria]: beman-tidy cannot actually check license.criteria. Please ignore this message if license.approved has passed. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#licensecriteria for more information.
Running check [Requirement][license.criteria] ... skipped

Running check [Recommendation][library.name] ... 
[info][library.name]: beman-tidy cannot actually check library.name. Please ignore this message if cmake.library_name and repository.name have passed. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#libraryname for more information.
[skipped][library.name]: beman-tidy cannot actually check library.name. Please ignore this message if cmake.library_name and repository.name have passed. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#libraryname for more information.
Running check [Recommendation][library.name] ... skipped

Running check [Requirement][repository.name] ... 
	check [Requirement][repository.name] ... passed

Running check [Requirement][repository.default_branch] ... 
	check [Requirement][repository.default_branch] ... passed

Running check [Requirement][repository.codeowners] ... 
	check [Requirement][repository.codeowners] ... passed

Running check [Requirement][repository.code_review_rules] ... 
[info][repository.code_review_rules]: beman-tidy cannot actually check repository.code_review_rules. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#repositorycode_review_rules.
[skipped][repository.code_review_rules]: beman-tidy cannot actually check repository.code_review_rules. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#repositorycode_review_rules.
Running check [Requirement][repository.code_review_rules] ... skipped

Running check [Requirement][repository.disallow_git_submodules] ... 
	check [Requirement][repository.disallow_git_submodules] ... passed

Running check [Requirement][release.github] ... 
[info][release.github]: beman-tidy cannot actually check release.github. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#releasegithub.
[skipped][release.github]: beman-tidy cannot actually check release.github. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#releasegithub.
Running check [Requirement][release.github] ... skipped

Running check [Recommendation][release.notes] ... 
[info][release.notes]: beman-tidy cannot actually check release.notes. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#releasenotes.
[skipped][release.notes]: beman-tidy cannot actually check release.notes. See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#releasenotes.
Running check [Recommendation][release.notes] ... skipped

Running check [Requirement][release.godbolt_trunk_version] ... 
	check [Requirement][release.godbolt_trunk_version] ... passed

Running check [Requirement][toplevel.cmake] ... 
	check [Requirement][toplevel.cmake] ... passed

Running check [Requirement][toplevel.license] ... 
	check [Requirement][toplevel.license] ... passed

Running check [Requirement][toplevel.readme] ... 
	check [Requirement][toplevel.readme] ... passed

Running check [Requirement][readme.title] ... 
	check [Requirement][readme.title] ... passed

Running check [Requirement][readme.badges] ... 
	check [Requirement][readme.badges] ... passed

Running check [Recommendation][readme.purpose] ... 
[info][readme.purpose]: beman-tidy cannot actually check readme.purpose. Please add a one line summary describing the library's purpose.See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#readmepurpose.
[skipped][readme.purpose]: beman-tidy cannot actually check readme.purpose. Please add a one line summary describing the library's purpose.See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#readmepurpose.
Running check [Recommendation][readme.purpose] ... skipped

Running check [Requirement][readme.implements] ... 
	check [Requirement][readme.implements] ... passed

Running check [Requirement][readme.library_status] ... 
	check [Requirement][readme.library_status] ... passed

Running check [Requirement][readme.license] ... 
	check [Requirement][readme.license] ... passed

Running check [Requirement][directory.sources] ... 
	check [Requirement][directory.sources] ... passed

Running check [Requirement][directory.tests] ... 
	check [Requirement][directory.tests] ... passed

Running check [Requirement][directory.examples] ... 
	check [Requirement][directory.examples] ... passed

Running check [Requirement][directory.docs] ... 
	check [Requirement][directory.docs] ... passed

Running check [Requirement][directory.papers] ... 
	check [Requirement][directory.papers] ... passed

Running check [Requirement][file.copyright] ... 
	check [Requirement][file.copyright] ... passed

Running check [Requirement][cpp.namespace] ... 
	check [Requirement][cpp.namespace] ... passed


beman-tidy pipeline finished.

Summary    Requirement:  22 checks passed, 0 checks failed, 3 checks skipped,  19 checks not implemented.
Summary Recommendation:  0 checks passed, 0 checks failed, 3 checks skipped,  0 checks not implemented.

Coverage    Requirement: 100.00% (28/28 checks passed).
Coverage Recommendation:   0.00% (0/0 checks passed).
Coverage          TOTAL: 100.00% (28/28 checks passed).

```