### PR TITLE
Restore beman-tidy pre-commit hook unintentionally removed by e7f108cab6e5af830aeb30097878f3d555e3de1d

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,4 +39,10 @@ repos:
     hooks:
       - id: codespell
 
+  - repo: https://github.com/bemanproject/beman-tidy
+    rev: v0.3.1
+    hooks:
+    - id: beman-tidy
+      args: [".", "--verbose", "--require-all"]
+
 exclude: 'cookiecutter/|infra/'


### PR DESCRIPTION
This was an unintentional change caused by my automated update process misinterpreting the commit
https://github.com/bemanproject/exemplar/commit/068a39cb6df8f073c6907851e2b1766cc3682453 as meaning that beman-tidy should be removed from the pre-commit config. I caught this problem elsewhere but missed it here.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
